### PR TITLE
FIX: Use fixed version of gensim

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gensim
+gensim<=3.8.3
 networkx
 pandas
 SPARQLWrapper


### PR DESCRIPTION
Set version of gensim to 3.8.3 or smaller in order to avoid breaking changes (like, for instance, the change of `size` to `vector_size` in Word2Vec)